### PR TITLE
Update Invidious API endpoint

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,4 +1,4 @@
-const annotationsEndpoint = "https://invidio.us/api/v1/annotations/";
+const annotationsEndpoint = "https://invidious.snopyta.org/api/v1/annotations/";
 
 function fetchVideoAnnotations(videoId) {
 	if (videoId.length !== 11) { throw new Error("Video ID must be exactly 11 characters long"); }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Annotations Restored for YouTube™",
     "short_name": "Annotations Restored",
-    "version": "0.0.9",
+    "version": "0.0.10",
 
     "description": "Brings annotation support back to YouTube™!",
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,9 @@
     "description": "Brings annotation support back to YouTube™!",
 
     "permissions": [
-		"https://invidio.us/api/v1/annotations/*",
+		"https://invidious.snopyta.org/api/v1/annotations/*",
 		"https://gist.githubusercontent.com/*/raw/*",
-        "https://pastebin.com/raw/*"
+        	"https://pastebin.com/raw/*"
     ],
 
     "icons": {


### PR DESCRIPTION
Switches the endpoint to another Invidious instance (it was the second one listed on https://instances.invidio.us/). Note that this update will likely require extension users to accept permissions for connecting to the new domain. I removed the permission for the old domain as I don't see any reason to keep it. Also, until the new instance caches annotations, retrieval may be a bit slower.